### PR TITLE
1.0.3

### DIFF
--- a/app/src/test/java/com/fuzz/android/salvager/InnerClassExample.java
+++ b/app/src/test/java/com/fuzz/android/salvager/InnerClassExample.java
@@ -1,0 +1,21 @@
+package com.fuzz.android.salvager;
+
+import com.fuzz.android.salvage.core.Persist;
+
+/**
+ * Description:
+ *
+ * @author Andrew Grosner (Fuzz)
+ */
+
+public class InnerClassExample {
+
+    @Persist
+    public static class Inner {
+
+        int id;
+
+        String name;
+
+    }
+}

--- a/app/src/test/java/com/fuzz/android/salvager/PersistenceTest.kt
+++ b/app/src/test/java/com/fuzz/android/salvager/PersistenceTest.kt
@@ -67,4 +67,14 @@ class PersistenceTest {
         assertEquals(1, serializable.size)
         assertNotNull(serializable[0])
     }
+
+    @Test
+    fun testCanFindInnerClass() {
+
+        val inner = InnerClassExample.Inner()
+        Salvager.onSaveInstanceState(inner, Bundle(), "")
+
+        val restored = Salvager.onRestoreInstanceState(InnerClassExample.Inner::class.java, Bundle(), "")
+        assertNotNull(restored)
+    }
 }

--- a/app/src/test/java/com/fuzz/android/salvager/PersistenceTest.kt
+++ b/app/src/test/java/com/fuzz/android/salvager/PersistenceTest.kt
@@ -74,7 +74,7 @@ class PersistenceTest {
         val inner = InnerClassExample.Inner()
         Salvager.onSaveInstanceState(inner, Bundle(), "")
 
-        val restored = Salvager.onRestoreInstanceState(InnerClassExample.Inner::class.java, Bundle(), "")
+        val restored = Salvager.onRestoreInstanceState(InnerClassExample.Inner::class, Bundle(), "")
         assertNotNull(restored)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.2
+version=1.0.3
 version_code=1
 group=com.fuzz.android
 bt_siteUrl=https://github.com/fuzz-productions/Salvage

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/BaseDefinition.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/BaseDefinition.kt
@@ -100,7 +100,7 @@ abstract class BaseDefinition : TypeDefinition {
     }
 
     protected fun setOutputClassName(postfix: String) {
-        val outputName: String
+        var outputName: String
         if (elementClassName == null) {
             if (elementTypeName is ClassName) {
                 outputName = (elementTypeName as ClassName).simpleName()
@@ -112,6 +112,11 @@ abstract class BaseDefinition : TypeDefinition {
             }
         } else {
             outputName = elementClassName!!.simpleName()
+        }
+
+        val enclosing = elementClassName?.enclosingClassName()
+        if (enclosing != null) {
+            outputName = "${enclosing.simpleName()}\$$outputName"
         }
         outputClassName = ClassName.get(packageName, outputName + postfix)
     }

--- a/salvage/src/main/java/com/fuzz/android/salvage/Salvager.kt
+++ b/salvage/src/main/java/com/fuzz/android/salvage/Salvager.kt
@@ -55,6 +55,7 @@ object Salvager {
      * By default you should not use this method without a corresponding call to [onRestoreInstanceState]
      */
     @JvmStatic
+    @JvmOverloads
     fun <T : Any> onSaveInstanceState(obj: T?, bundle: Bundle?, uniqueBaseKey: String = "") {
         if (obj == null || bundle == null) {
             return
@@ -71,6 +72,7 @@ object Salvager {
      * By default you should not use this method without a corresponding call to [onSaveInstanceState]
      */
     @JvmStatic
+    @JvmOverloads
     fun <T : Any> onRestoreInstanceState(obj: T?, bundle: Bundle?, uniqueBaseKey: String = ""): T? {
         return if (obj == null || bundle == null) {
             null
@@ -78,5 +80,25 @@ object Salvager {
             getBundlePersister(obj.javaClass).unpack(obj, bundle, uniqueBaseKey)
         }
     }
+
+
+    /**
+     * Restore your state here.
+     * [obj] the Class of the object to restore. Will return a new instance.
+     * [bundle] the bundle to restore. If null we ignore restoring.
+     * [uniqueBaseKey] default is "". If specified it will adjust every key of every object saved
+     * by prepending this key to the base. This is to ensure we can restore any nested object in same bundle.
+     * By default you should not use this method without a corresponding call to [onSaveInstanceState]
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun <T : Any> onRestoreInstanceState(obj: Class<T>, bundle: Bundle?, uniqueBaseKey: String = ""): T? {
+        return if (bundle == null) {
+            null
+        } else {
+            getBundlePersister(obj).unpack(null, bundle, uniqueBaseKey)
+        }
+    }
+
 
 }

--- a/salvage/src/main/java/com/fuzz/android/salvage/Salvager.kt
+++ b/salvage/src/main/java/com/fuzz/android/salvage/Salvager.kt
@@ -2,6 +2,7 @@ package com.fuzz.android.salvage
 
 import android.os.Bundle
 import java.io.Serializable
+import kotlin.reflect.KClass
 
 @Suppress("UNCHECKED_CAST")
 /**
@@ -100,5 +101,16 @@ object Salvager {
         }
     }
 
+    /**
+     * Restore your state here.
+     * [obj] the Class of the object to restore. Will return a new instance.
+     * [bundle] the bundle to restore. If null we ignore restoring.
+     * [uniqueBaseKey] default is "". If specified it will adjust every key of every object saved
+     * by prepending this key to the base. This is to ensure we can restore any nested object in same bundle.
+     * By default you should not use this method without a corresponding call to [onSaveInstanceState]
+     */
+    fun <T : Any> onRestoreInstanceState(obj: KClass<T>, bundle: Bundle?, uniqueBaseKey: String = ""): T? {
+        return onRestoreInstanceState(obj.java, bundle, uniqueBaseKey)
+    }
 
 }


### PR DESCRIPTION
1. Fixes issue where inner classes were not generating `BundlePersister` with outerclass name.
2. Add `@JvmOverloads` to have Kotlin create multiple methods with default args.
