### PR TITLE
1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,28 +152,31 @@ var name: String = ""
 ### Field Detection
 
 By default, `Salvage` looks for all fields (and in all parent classes) that are:
-1. public
-2. package private
-3. private (with both getter / setter specified as bean)
+  1. public
+  2. package private
+  3. private (with both getter / setter specified as bean)
 
 Also they may be `val` (`final` in Java) if you use a nested `@Persist` or
 custom `BundlePersister` to reuse the same instance if you wish to instantiate
 the instance yourself.
 
 `Salvage` ignores:
-1. `transient`
-2. `private` fields missing a getter or setter.
-3. Fields annotated with `@PersistIgnore`
-4. `static` fields (`@JvmStatic`)
+  1. `transient`
+  2. `private` fields missing a getter or setter.
+  3. Fields annotated with `@PersistIgnore`
+  4. `static` fields (`@JvmStatic`)
 
 #### Persist Policy
 
 Instead of having to manually add `@PersistIgnore` or get stuck when you subclass an external object that you cannot control, you can tweak the `PersistPolicy`.
 
-`VISIBLE_FIELDS_AND_METHODS`: Default lookup mechanism.
-`VISIBLE_FIELDS_ONLY`: package private or public fields only
-`ANNOTATIONS_ONLY` : explicity specify `@PersistField`
-`PRIVATE_ACCESSORS_ONLY`: any private fields that have accessors
+  `VISIBLE_FIELDS_AND_METHODS`: Default lookup mechanism.
+
+  `VISIBLE_FIELDS_ONLY`: package private or public fields only
+
+  `ANNOTATIONS_ONLY` : explicity specify `@PersistField`
+
+  `PRIVATE_ACCESSORS_ONLY`: any private fields that have accessors
 
 ## Maintainer
 [agrosner](https://github.com/agrosner) ([@agrosner](https://www.twitter.com/agrosner))

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the the artifacts to the project-level build.gradle:
 
 ```
 
-def salvage_version = "1.0.2"
+def salvage_version = "1.0.4"
 
 dependencies {
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ dependencies {
 
 ```
 
+## Proguard
+
+Proguard configuration is:
+
+```
+-keep class * extends com.fuzz.android.salvage.BundlePersister { *; }
+```
+Since we use reflection to instantiate persisters as we use them, we need to ensure
+the class is kept around.
+
 ## How To Use
 
 Simple as annotating your class:
@@ -139,15 +149,31 @@ var name: String = ""
 
 ```
 
-## Proguard
+### Field Detection
 
-Proguard configuration is:
+By default, `Salvage` looks for all fields (and in all parent classes) that are:
+1. public
+2. package private
+3. private (with both getter / setter specified as bean)
 
-```
--keep class * extends com.fuzz.android.salvage.BundlePersister { *; }
-```
-Since we use reflection to instantiate persisters as we use them, we need to ensure
-the class is kept around.
+Also they may be `val` (`final` in Java) if you use a nested `@Persist` or
+custom `BundlePersister` to reuse the same instance if you wish to instantiate
+the instance yourself.
+
+`Salvage` ignores:
+1. `transient`
+2. `private` fields missing a getter or setter.
+3. Fields annotated with `@PersistIgnore`
+4. `static` fields (`@JvmStatic`)
+
+#### Persist Policy
+
+Instead of having to manually add `@PersistIgnore` or get stuck when you subclass an external object that you cannot control, you can tweak the `PersistPolicy`.
+
+`VISIBLE_FIELDS_AND_METHODS`: Default lookup mechanism.
+`VISIBLE_FIELDS_ONLY`: package private or public fields only
+`ANNOTATIONS_ONLY` : explicity specify `@PersistField`
+`PRIVATE_ACCESSORS_ONLY`: any private fields that have accessors
 
 ## Maintainer
 [agrosner](https://github.com/agrosner) ([@agrosner](https://www.twitter.com/agrosner))

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Simple as annotating your class:
 
 ```kotlin
 
+// must provide visible default constructor
 @Persist
 data class User(var name: String? = null, var age: Int = 0)
 
@@ -43,6 +44,7 @@ data class User(var name: String? = null, var age: Int = 0)
 or in Java
 ```java
 
+// must provide visible default constructor
 @Persist
 public class User {
 
@@ -75,21 +77,16 @@ Then in your `Fragment`, `Activity`, or other class that uses `Bundle` states:
 
     private var user: User? = null
 
-    @Override
-    public void onSaveInstanceState(@NonNull Bundle bundle) {
+    override fun onSaveInstanceState(bundle: Bundle) {
         super.onSaveInstanceState(bundle)
         Salvager.onSaveInstanceState(user, bundle)
     }
 
-    @Override
-    public void onRestoreInstanceState(@NonNull Bundle bundle) {
+    override fun onRestoreInstanceState(bundle: Bundle) {
         super.onRestoreInstanceState(bundle);
-        val myUser = user
-        if (myUser == null) {
-          myUser = User()
-        }
-        Salvager.onRestoreInstanceState(myUser, bundle)
-        user = myUser
+        // restore, if user not null, we reuse the object to not unnecessarily
+        // recreate instance. If null, we create a new instance
+        user = Salvager.onRestoreInstanceState(user, bundle)
 
         // do something with restored state
       }

--- a/android-kotlin-artifacts.gradle
+++ b/android-kotlin-artifacts.gradle
@@ -1,0 +1,40 @@
+apply plugin: 'com.github.dcendents.android-maven'
+
+install {
+    repositories.mavenInstaller {
+        pom {
+            project {
+                packaging bt_packaging
+                name bt_name
+                url bt_siteUrl
+                licenses {
+                    license {
+                        name bt_licenseName
+                        url bt_licenseUrl
+                    }
+                }
+                scm {
+                    connection bt_gitUrl
+                    developerConnection bt_gitUrl
+                    url bt_siteUrl
+                }
+            }
+        }
+    }
+}
+
+// restore when found.
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+/*task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}*/
+
+artifacts {
+    archives sourcesJar
+    //archives javadocJar
+}

--- a/app/src/test/java/com/fuzz/android/salvager/Example.kt
+++ b/app/src/test/java/com/fuzz/android/salvager/Example.kt
@@ -21,17 +21,20 @@ data class Example(@PersistField(bundlePersister = CustomStringPersister::class)
 class SimpleSerializable : Serializable
 
 @Persist
-data class ParentObject(var example: Example? = null)
+data class ParentObject(var example: Example? = null,
+                        val finalExample: Example? = null)
 
 @Persist
 data class ListExample(var list: List<ParentObject> = arrayListOf(),
                        var listString: List<String> = arrayListOf(),
-                       var listSerializable: List<SimpleSerializable> = arrayListOf())
+                       var listSerializable: List<SimpleSerializable> = arrayListOf(),
+                       val finalList: List<ParentObject> = arrayListOf())
 
 @Persist
 data class MapExample(var map: Map<String, ParentObject> = mutableMapOf(),
                       var mapComplex: Map<ParentObject, ParentObject> = mutableMapOf(),
-                      var mapSerializable: Map<SimpleSerializable, Int> = mutableMapOf())
+                      var mapSerializable: Map<SimpleSerializable, Int> = mutableMapOf(),
+                      val finalMap: MutableMap<String, ParentObject> = mutableMapOf())
 
 class CustomStringPersister : BundlePersister<String> {
     override fun persist(obj: String?, bundle: Bundle, uniqueBaseKey: String) {

--- a/app/src/test/java/com/fuzz/android/salvager/InnerClassExample.java
+++ b/app/src/test/java/com/fuzz/android/salvager/InnerClassExample.java
@@ -17,5 +17,6 @@ public class InnerClassExample {
 
         String name;
 
+        final Example example = new Example();
     }
 }

--- a/app/src/test/java/com/fuzz/android/salvager/InnerClassExample.java
+++ b/app/src/test/java/com/fuzz/android/salvager/InnerClassExample.java
@@ -1,6 +1,8 @@
 package com.fuzz.android.salvager;
 
 import com.fuzz.android.salvage.core.Persist;
+import com.fuzz.android.salvage.core.PersistField;
+import com.fuzz.android.salvage.core.PersistPolicy;
 
 /**
  * Description:
@@ -10,13 +12,19 @@ import com.fuzz.android.salvage.core.Persist;
 
 public class InnerClassExample {
 
-    @Persist
+    @Persist(persistPolicy = PersistPolicy.ANNOTATIONS_ONLY)
     public static class Inner {
 
+        @PersistField
         int id;
 
+        @PersistField
         String name;
 
+        @PersistField
+        boolean isSet;
+
+        @PersistField
         final Example example = new Example();
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.3
+version=1.0.4
 version_code=1
 group=com.fuzz.android
 bt_siteUrl=https://github.com/fuzz-productions/Salvage

--- a/salvage-core/src/main/java/com/fuzz/android/salvage/core/Annotations.kt
+++ b/salvage-core/src/main/java/com/fuzz/android/salvage/core/Annotations.kt
@@ -15,6 +15,11 @@ enum class PersistPolicy {
     VISIBLE_FIELDS_AND_METHODS,
 
     /**
+     * Package private or public fields are only included.
+     */
+    VISIBLE_FIELDS_ONLY,
+
+    /**
      * Any annotated field with [PersistField]. If they are private + have associated accessors,
      * they're counted too.
      */

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/Accessors.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/Accessors.kt
@@ -173,19 +173,18 @@ class PackagePrivateScopeAccessor(propertyName: String, packageName: String,
     }
 }
 
-class NormalAccessor(val bundleMethodName: String, val keyFieldName: String, propertyName: String? = null)
+/**
+ * Used for complex [List] or [Map] or Nested types that are final, we don't reassign, we just
+ * attempt to assign fields to it.
+ */
+class EmptyAccessor(propertyName: String? = null)
     : Accessor(propertyName) {
     override fun get(existingBlock: CodeBlock?, baseVariableName: String?): CodeBlock {
-        return appendAccess {
-            addStatement("bundle.put\$L(\$L + \$L, \$L)",
-                    bundleMethodName, uniqueBaseKey, keyFieldName, existingBlock)
-        }
+        return appendAccess { add(existingBlock) }
     }
 
     override fun set(existingBlock: CodeBlock?, baseVariableName: CodeBlock?): CodeBlock {
-        return appendAccess {
-
-        }
+        return appendAccess { add(existingBlock) }
     }
 
 }

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/Accessors.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/Accessors.kt
@@ -206,8 +206,8 @@ class NestedAccessor(val persisterFieldName: String,
 
         return appendAccess {
             addStatement(baseFieldAcessor.set(
-                    CodeBlock.of("\$L.unpack(null, bundle, \$L + $keyFieldName)",
-                            persisterFieldName, uniqueBaseKey),
+                    CodeBlock.of("\$L.unpack(\$L, bundle, \$L + $keyFieldName)",
+                            persisterFieldName, existingBlock, uniqueBaseKey),
                     baseVariableName))
         }
     }
@@ -228,8 +228,8 @@ class ListAccessor(val keyFieldName: String,
     override fun set(existingBlock: CodeBlock?, baseVariableName: CodeBlock?): CodeBlock {
         return appendAccess {
             addStatement(baseFieldAcessor.set(
-                    CodeBlock.of("restoreList(bundle, $uniqueBaseKey, $keyFieldName, " +
-                            "$persisterFieldName)"),
+                    CodeBlock.of("restoreList(\$L, bundle, $uniqueBaseKey, $keyFieldName, " +
+                            "$persisterFieldName)", existingBlock),
                     baseVariableName))
         }
     }
@@ -252,8 +252,8 @@ class MapAccessor(val keyFieldName: String,
     override fun set(existingBlock: CodeBlock?, baseVariableName: CodeBlock?): CodeBlock {
         return appendAccess {
             addStatement(baseFieldAcessor.set(
-                    CodeBlock.of("restoreMap(bundle, $uniqueBaseKey, $keyFieldName, " +
-                            "$keyPersisterFieldName, $persisterFieldName)"),
+                    CodeBlock.of("restoreMap(\$L, bundle, $uniqueBaseKey, $keyFieldName, " +
+                            "$keyPersisterFieldName, $persisterFieldName)", existingBlock),
                     baseVariableName))
         }
     }

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/ElementUtility.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/ElementUtility.kt
@@ -42,7 +42,6 @@ object ElementUtility {
     fun isValidAllFields(allFields: Boolean, element: Element): Boolean {
         return allFields && element.kind.isField &&
                 !element.modifiers.contains(Modifier.STATIC) &&
-                !element.modifiers.contains(Modifier.FINAL) &&
                 element.getAnnotation(PersistIgnore::class.java) == null
     }
 

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/ElementUtility.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/ElementUtility.kt
@@ -41,6 +41,7 @@ object ElementUtility {
 
     fun isValidAllFields(allFields: Boolean, element: Element): Boolean {
         return allFields && element.kind.isField &&
+                !element.modifiers.contains(Modifier.TRANSIENT) &&
                 !element.modifiers.contains(Modifier.STATIC) &&
                 element.getAnnotation(PersistIgnore::class.java) == null
     }

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/Fields.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/Fields.kt
@@ -115,17 +115,19 @@ class BasicField(manager: ProcessorManager,
 }
 
 class CustomField(manager: ProcessorManager,
-                  persistenceField: PersistenceField) : Field(manager, persistenceField) {
+                  persistenceField: PersistenceField,
+                  val isFinal: Boolean) : Field(manager, persistenceField) {
     override val nestedAccessor: Accessor
         get() = NestedAccessor(persistenceField.persisterFieldName,
-                persistenceField.keyFieldName, persistenceField.accessor)
+                persistenceField.keyFieldName, if (isFinal) EmptyAccessor() else persistenceField.accessor)
 
     override fun initialize() {
     }
 }
 
 class ListField(manager: ProcessorManager,
-                persistenceField: PersistenceField) : Field(manager, persistenceField) {
+                persistenceField: PersistenceField,
+                val isFinal: Boolean) : Field(manager, persistenceField) {
 
     var componentTypeName: TypeName? = null
     var componentElement: TypeElement? = null
@@ -146,7 +148,7 @@ class ListField(manager: ProcessorManager,
         get() = componentTypeName
 
     override val nestedAccessor: Accessor? by lazy {
-        ListAccessor(persistenceField.keyFieldName, persistenceField.accessor,
+        ListAccessor(persistenceField.keyFieldName, if (isFinal) EmptyAccessor() else persistenceField.accessor,
                 persistenceField.persisterFieldName)
     }
 
@@ -163,7 +165,8 @@ class ListField(manager: ProcessorManager,
 }
 
 class MapField(manager: ProcessorManager,
-               persistenceField: PersistenceField) : Field(manager, persistenceField) {
+               persistenceField: PersistenceField,
+               val isFinal: Boolean) : Field(manager, persistenceField) {
 
     var componentTypeName: TypeName? = null
     var componentElement: TypeElement? = null
@@ -196,7 +199,7 @@ class MapField(manager: ProcessorManager,
         get() = persistenceField.elementName + "_keypersister"
 
     override val nestedAccessor: Accessor? by lazy {
-        MapAccessor(persistenceField.keyFieldName, persistenceField.accessor,
+        MapAccessor(persistenceField.keyFieldName, if (isFinal) EmptyAccessor() else persistenceField.accessor,
                 persistenceField.persisterFieldName, keyPersisterFieldName)
     }
 

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/Fields.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/Fields.kt
@@ -60,7 +60,12 @@ class FieldHolder(val manager: ProcessorManager,
 
     fun writeFields(typeBuilder: TypeSpec.Builder) {
         if (!hasBundleMethod || hasCustomConverter) {
-            typeBuilder.addField(persisterDefinitionTypeName, persisterFieldName,
+            val persisterTypeName = if (isSerializable) {
+                ParameterizedTypeName.get(SERIALIZABLE_PERSISTER, basicTypeName)
+            } else {
+                persisterDefinitionTypeName
+            }
+            typeBuilder.addField(persisterTypeName, persisterFieldName,
                     Modifier.PRIVATE, Modifier.FINAL)
         }
     }

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/PersistenceDefinition.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/PersistenceDefinition.kt
@@ -56,6 +56,8 @@ class PersistenceDefinition(typeElement: TypeElement, manager: ProcessorManager)
                     isValidField = it.getAnnotation(PersistField::class.java) != null
                 } else if (persistPolicy == PersistPolicy.PRIVATE_ACCESSORS_ONLY) {
                     isValidField = it.modifiers.contains(Modifier.PRIVATE)
+                } else if (persistPolicy == PersistPolicy.VISIBLE_FIELDS_ONLY) {
+                    isValidField = !it.modifiers.contains(Modifier.PRIVATE)
                 }
                 if (isValidField) {
                     val persistenceField = PersistenceField(manager, it, isPackagePrivateNotInSamePackage)

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/PersistenceField.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/PersistenceField.kt
@@ -54,8 +54,11 @@ class PersistenceField(manager: ProcessorManager, element: Element, isPackagePri
             try {
                 annotation.bundlePersister
             } catch (mte: MirroredTypeException) {
-                persisterDefinitionTypeName = ClassName.get(mte.typeMirror)
-                hasCustomConverter = true
+                val typeName = ClassName.get(mte.typeMirror)
+                if (typeName != TypeName.OBJECT) {
+                    persisterDefinitionTypeName = typeName
+                    hasCustomConverter = true
+                }
             }
 
             getterName = annotation.getterName

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/PersistenceField.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/PersistenceField.kt
@@ -44,6 +44,9 @@ class PersistenceField(manager: ProcessorManager, element: Element, isPackagePri
 
     init {
 
+        // final fields won't get assigned to
+        val isFinal = element.modifiers.contains(Modifier.FINAL)
+
         val annotation = element.getAnnotation(PersistField::class.java)
         var getterName = ""
         var setterName = ""
@@ -111,11 +114,11 @@ class PersistenceField(manager: ProcessorManager, element: Element, isPackagePri
         bundleMethodName = if (typeName != null) ClassLookupMap.valueForType(typeName, isSerializable) ?: "" else ""
 
         if (isList) {
-            field = ListField(manager, this)
+            field = ListField(manager, this, isFinal)
         } else if (isMap) {
-            field = MapField(manager, this)
+            field = MapField(manager, this, isFinal)
         } else if (isSerializable || isNested || hasCustomConverter) {
-            field = CustomField(manager, this)
+            field = CustomField(manager, this, isFinal)
         } else {
             field = BasicField(manager, this)
         }

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/PersistenceField.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/PersistenceField.kt
@@ -147,7 +147,8 @@ class PersistenceField(manager: ProcessorManager, element: Element, isPackagePri
                 accessedBlock = accessor.set(block, CodeBlock.of(defaultParam))
                 methodBuilder.addStatement(accessedBlock)
             } else {
-                accessedBlock = nestedAccessor.set(block, CodeBlock.of(defaultParam))
+                accessedBlock = nestedAccessor.set(accessor.get(CodeBlock.of(defaultParam), null),
+                        CodeBlock.of(defaultParam))
                 methodBuilder.addCode(accessedBlock)
             }
         }

--- a/salvage-processor/src/main/java/com/fuzz/android/salvage/ProcessorManager.kt
+++ b/salvage-processor/src/main/java/com/fuzz/android/salvage/ProcessorManager.kt
@@ -39,11 +39,11 @@ class ProcessorManager(val processingEnvironment: ProcessingEnvironment) : Handl
 
     fun logError(error: String?, vararg args: Any?) = logError(callingClass = null, error = error, args = args)
 
-    fun logWarning(error: String, vararg args: Any) {
+    fun logWarning(error: String, vararg args: Any?) {
         messager.printMessage(Diagnostic.Kind.WARNING, String.format("*==========*\n$error\n*==========*", *args))
     }
 
-    fun logWarning(callingClass: Class<*>, error: String, vararg args: Any) {
+    fun logWarning(callingClass: KClass<*>, error: String, vararg args: Any?) {
         logWarning("$callingClass : $error", *args)
     }
 

--- a/salvage/build.gradle
+++ b/salvage/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     compile project(":salvage-core")
 }
 
-apply from: '../kotlin-artifacts.gradle'
+apply from: '../android-kotlin-artifacts.gradle'
 

--- a/salvage/src/main/java/com/fuzz/android/salvage/BaseBundlePersister.kt
+++ b/salvage/src/main/java/com/fuzz/android/salvage/BaseBundlePersister.kt
@@ -30,13 +30,16 @@ abstract class BaseBundlePersister<T> : BundlePersister<T> {
         }
     }
 
-    protected fun <T : Any> restoreList(bundle: Bundle, uniqueBaseKey: String,
+    protected fun <T : Any> restoreList(existingList: MutableList<T>?,
+                                        bundle: Bundle, uniqueBaseKey: String,
                                         fieldKey: String, bundlePersister: BundlePersister<T>): List<T>? {
+        val list = existingList ?: arrayListOf()
+        list.clear()
         val count = bundle.getInt(getCountKey(fieldKey, uniqueBaseKey), 0)
         if (count > 0) {
-            return (0..count - 1).mapNotNull {
+            return (0..count - 1).mapNotNullTo(list, {
                 bundlePersister.unpack(null, bundle, "$uniqueBaseKey$fieldKey$it")
-            }
+            })
         }
         return null
     }
@@ -61,13 +64,15 @@ abstract class BaseBundlePersister<T> : BundlePersister<T> {
     }
 
     protected fun <K : Any, V : Any> restoreMap(
+            existingMap: MutableMap<K, V?>?,
             bundle: Bundle, uniqueBaseKey: String,
             fieldKey: String,
             keyBundlePersister: BundlePersister<K>,
             variableBundlePersister: BundlePersister<V>): Map<K, V?>? {
+        val map = existingMap ?: mutableMapOf()
+        map.clear()
         val count = bundle.getInt(getCountKey(fieldKey, uniqueBaseKey), 0)
         if (count > 0) {
-            val map: MutableMap<K, V?> = mutableMapOf()
             (0..count - 1).forEach {
                 val key = keyBundlePersister
                         .unpack(null, bundle, getMapKey(fieldKey, it, uniqueBaseKey))

--- a/salvage/src/main/java/com/fuzz/android/salvage/Salvager.kt
+++ b/salvage/src/main/java/com/fuzz/android/salvage/Salvager.kt
@@ -65,6 +65,24 @@ object Salvager {
     }
 
     /**
+     * Save your state here.
+     * [obj] the nullable object to save. If null we ignore saving
+     * [bundle] the bundle to save. If null we ignore saving
+     * [uniqueBaseKey] default is "". If specified it will adjust every key of every object saved
+     * by prepending this key to the base. This is to ensure we can store any nested object in same bundle.
+     * By default you should not use this method without a corresponding call to [onRestoreInstanceState]
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun <T : Any> onSaveInstanceState(obj: T?, uniqueBaseKey: String = ""): Bundle {
+        val bundle = Bundle()
+        if (obj != null) {
+            getBundlePersister(obj.javaClass).persist(obj, bundle, uniqueBaseKey)
+        }
+        return bundle
+    }
+
+    /**
      * Restore your state here.
      * [obj] the nullable object to restore. If null we ignore restoring. So ensure its not null.
      * [bundle] the bundle to restore. If null we ignore restoring.


### PR DESCRIPTION
1. Adds ability to reuse nested `@Persist`, custom `BundlePersister` fields, `List`, `Map`, and other objects. 
2. support `final` / `val` fields by not setting value but only reusing existing value in persist and unpacker.
3. any field marked with `transient` is ignored.
4. ignore fields that don't have both getter / setter. If missing a warning will get thrown.
5. Add `PersistencePolicy` to find visible fields only `VISIBLE_FIELDS_ONLY`.
6. Adds a new method that when no `Bundle` is passed into `onSaveInstanceState()`, we return a new `Bundle`. This is useful for nesting `Bundle`.
7. Fix issue where fields that have `@PersistField` were treated as a `BundlePersister` of `Object`.